### PR TITLE
Chore/refactor: Export submodules, remove unnecessary expression, and more

### DIFF
--- a/src/beans/file_info.rs
+++ b/src/beans/file_info.rs
@@ -12,20 +12,18 @@ pub struct FileInfo {
 }
 
 pub fn parse_file_info<T: ToString>(data: Vec<u8>, path: T) -> Result<FileInfo> {
-    let mut mode = 0;
-    let mut size = 0;
-    let mut mtime = 0;
-    let mut mdtime = None;
     let mode_bytes = &data[0..4];
     let size_bytes = &data[4..8];
     let mtime_bytes = &data[8..12];
-    mode = u32::from_le_bytes(mode_bytes.try_into().unwrap());
-    size = u32::from_le_bytes(size_bytes.try_into().unwrap());
-    mtime = u32::from_le_bytes(mtime_bytes.try_into().unwrap());
-    mdtime = Some(
+
+    let mode = u32::from_le_bytes(mode_bytes.try_into()?);
+    let size = u32::from_le_bytes(size_bytes.try_into()?);
+    let mtime = u32::from_le_bytes(mtime_bytes.try_into()?);
+    let mdtime = Some(
         chrono::DateTime::<Utc>::from_timestamp(mtime as i64, 0)
             .ok_or(anyhow!("Parse Datetime Error"))?,
     );
+
     Ok(FileInfo::new(mode, size, mtime, mdtime, path.to_string()))
 }
 

--- a/src/beans/forward_item.rs
+++ b/src/beans/forward_item.rs
@@ -1,13 +1,13 @@
 #[derive(Debug)]
-pub struct ForwardIterm {
+pub struct ForwardItem {
     pub(crate) serial: String,
     pub(crate) local: String,
     pub(crate) remote: String,
 }
 
-impl ForwardIterm {
-    pub fn new(serial: &str, local: &str, remote: &str) -> ForwardIterm {
-        ForwardIterm {
+impl ForwardItem {
+    pub fn new(serial: &str, local: &str, remote: &str) -> ForwardItem {
+        ForwardItem {
             serial: serial.to_string(),
             local: local.to_string(),
             remote: remote.to_string(),

--- a/src/beans/mod.rs
+++ b/src/beans/mod.rs
@@ -7,5 +7,5 @@ pub(crate) mod net_info;
 pub use app_info::AppInfo;
 pub use device_info::AdbDeviceInfo;
 pub use file_info::{FileInfo,parse_file_info};
-pub use forward_item::ForwardIterm;
+pub use forward_item::ForwardItem;
 pub use net_info::NetworkType;

--- a/src/beans/mod.rs
+++ b/src/beans/mod.rs
@@ -1,5 +1,11 @@
-pub mod app_info;
-pub mod device_info;
-pub mod file_info;
-pub mod forward_item;
-pub mod net_info;
+pub(crate) mod app_info;
+pub(crate) mod device_info;
+pub(crate) mod file_info;
+pub(crate) mod forward_item;
+pub(crate) mod net_info;
+
+pub use app_info::AppInfo;
+pub use device_info::AdbDeviceInfo;
+pub use file_info::{FileInfo,parse_file_info};
+pub use forward_item::ForwardIterm;
+pub use net_info::NetworkType;

--- a/src/client/adb_connection.rs
+++ b/src/client/adb_connection.rs
@@ -31,7 +31,7 @@ impl AdbConnection {
         if sock_addr.is_none() & timeout.is_none(){
             return Self::default()
         }else{
-            let mut config = match sock_addr {
+            let config = match sock_addr {
                 Some(sock_addr) => AdbSocketConfig::new(sock_addr, timeout),
                 _ => AdbSocketConfig::new(SocketAddr::new("127.0.0.1:5037".parse::<IpAddr>().unwrap(), 5037), timeout)
             };

--- a/src/client/adb_device.rs
+++ b/src/client/adb_device.rs
@@ -1,4 +1,4 @@
-use crate::beans::app_info::AppInfo;
+use crate::beans::AppInfo;
 use crate::beans::device_info::AdbDeviceInfo;
 use crate::beans::file_info::{parse_file_info, FileInfo};
 use crate::beans::forward_item::ForwardIterm;

--- a/src/client/adb_device.rs
+++ b/src/client/adb_device.rs
@@ -767,10 +767,10 @@ impl AdbDevice {
     }
     pub fn logcat(& mut self, flush_exist: bool, command: Option<&str>, lock: Arc<RwLock<bool>>) -> anyhow::Result<impl Iterator<Item = String>> {
 
-        if (flush_exist) {
+        if flush_exist {
             self.shell(&["logcat", "-c"])?;
         }
-        let mut conn = self.shell_stream(&["logcat", "-v", "time"])?;
+        let conn = self.shell_stream(&["logcat", "-v", "time"])?;
         return Ok(std::iter::from_fn(move || {
                 let mut bufreader = BufReader::new(&conn.stream);
 

--- a/src/client/adb_device.rs
+++ b/src/client/adb_device.rs
@@ -1,7 +1,7 @@
 use crate::beans::AppInfo;
 use crate::beans::device_info::AdbDeviceInfo;
 use crate::beans::file_info::{parse_file_info, FileInfo};
-use crate::beans::forward_item::ForwardIterm;
+use crate::beans::forward_item::ForwardItem;
 use crate::beans::net_info::NetworkType;
 use crate::client::adb_connection::AdbConnection;
 use crate::connections::adb_protocol::AdbProtocolStreamHandler;
@@ -278,7 +278,7 @@ impl AdbDevice {
         Err(anyhow!("Failed To Forward Port"))
     }
 
-    pub fn forward_list(&mut self) -> anyhow::Result<Vec<ForwardIterm>> {
+    pub fn forward_list(&mut self) -> anyhow::Result<Vec<ForwardItem>> {
         let mut connection = self.open_transport(Some("list-forward"))?;
         let content = connection.read_string_block()?;
         let mut forward_iterms = vec![];
@@ -287,7 +287,7 @@ impl AdbDevice {
             if current_parts.len() == 3 {
                 let (serial, local, remote) =
                     (current_parts[0], current_parts[1], current_parts[2]);
-                forward_iterms.push(ForwardIterm::new(serial, local, remote))
+                forward_iterms.push(ForwardItem::new(serial, local, remote))
             }
         }
         Ok(forward_iterms)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,2 +1,5 @@
-pub mod adb_device;
-pub mod adb_connection;
+pub(crate) mod adb_device;
+pub(crate) mod adb_connection;
+
+pub use adb_connection::AdbConnection;
+pub use adb_device::AdbDevice;

--- a/src/connections/adb_socket_config.rs
+++ b/src/connections/adb_socket_config.rs
@@ -1,13 +1,13 @@
 use crate::utils::start_adb_server;
 use log::error;
-use std::net::{IpAddr, SocketAddr, TcpStream};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
 use std::time::Duration;
 use anyhow::Context;
 
 const DEFAULT_ADB_PORT: u16 = 5037;
 const DEFAULT_ADB_TIMEOUT: u64 = 3;
 
-const DEFAULT_ADB_HOST: &str = "127.0.0.1";
+const DEFAULT_ADB_HOST: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
 
 ///
 /// Adb Socket相关配置
@@ -24,7 +24,7 @@ impl Default for AdbSocketConfig {
     fn default() -> Self {
         AdbSocketConfig {
             addr: SocketAddr::new(
-                DEFAULT_ADB_HOST.parse::<IpAddr>().unwrap(),
+                IpAddr::V4(DEFAULT_ADB_HOST),
                 DEFAULT_ADB_PORT,
             ),
             timeout: DEFAULT_ADB_TIMEOUT,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,7 @@ pub mod beans;
 pub mod client;
 pub mod connections;
 pub mod utils;
+
+pub use beans::{AppInfo, AdbDeviceInfo, FileInfo, ForwardIterm, NetworkType};
+pub use client::{AdbConnection, AdbDevice};
+pub use utils::adb_path;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,6 @@ pub mod client;
 pub mod connections;
 pub mod utils;
 
-pub use beans::{AppInfo, AdbDeviceInfo, FileInfo, ForwardIterm, NetworkType};
+pub use beans::{AppInfo, AdbDeviceInfo, FileInfo, ForwardItem, NetworkType};
 pub use client::{AdbConnection, AdbDevice};
 pub use utils::adb_path;

--- a/tests/test_adb.rs
+++ b/tests/test_adb.rs
@@ -1,8 +1,8 @@
 
 #[cfg(test)]
 mod test_adb{
-    use radb::client::adb_connection::AdbConnection;
-    use radb::client::adb_device::AdbDevice;
+    use radb::client::AdbConnection;
+    use radb::client::AdbDevice;
 
     #[test]
     fn test_adb_list_devices(){

--- a/tests/test_devices.rs
+++ b/tests/test_devices.rs
@@ -7,9 +7,9 @@ mod test_devices{
     use std::time::Duration;
     use chrono::{DateTime, TimeZone, Utc};
     use log::info;
-    use radb::beans::app_info::AppInfo;
-    use radb::beans::file_info::FileInfo;
-    use radb::client::adb_device::AdbDevice;
+    use radb::beans::AppInfo;
+    use radb::beans::FileInfo;
+    use radb::client::AdbDevice;
     use radb::utils::init_logger;
 
 


### PR DESCRIPTION
## Changes
### Export structs from the submodule
* Commit: f611fe8fe78462387d99865b90bc0717f4f7d551
* So users can use this library more easily (see below)

```rust
// BEFORE
use radb::client::adb_connection::AdbConnection;
// ...
```

```rust
// AFTER
use radb::AdbConnection;
// OR
use radb::client::AdbConnection;
// ...
```

### Remove unnecessary expressions
* Commits: df246c22e2d16b9e84f54443670f5287d4b7b798 and df246c22e2d16b9e84f54443670f5287d4b7b798
* Removed unnecessary `mut` and parentheses
* Unused imports haven't been removed yet

### Use `Ipv4Addr` for DEFAULT_ADB_HOST
* Commit: df246c22e2d16b9e84f54443670f5287d4b7b798
* To be more expressive

### Fix typo: `ForwardIterm` -> `ForwardItem` 
* Commit: 666fdab9d9ccd16875d2394cc373546c9df26951